### PR TITLE
[github-actions] Add new workflow for auto-assign reviewers

### DIFF
--- a/.github/assign-by-files.yml
+++ b/.github/assign-by-files.yml
@@ -1,0 +1,23 @@
+# GitHub stuff
+'.github/*':
+  - AndreiJirohHaliliDev2006
+  
+# GitLab stuff
+'.gitlab/*':
+  - AndreiJirohHaliliDev2006
+
+# StickPage entries
+'stickpage/*.json':
+  - ThePinsTeam
+  
+# Stick character animator entries
+'animators/*.json':
+  - ThePinsTeam
+  
+# Stuff related to Slushers
+'slushers/*.json':
+  - ThePinsTeam
+  
+# Script files
+'bin/*':
+  - AndreiJirohHaliliDev2006

--- a/.github/workflows/auto-assign-pr-reviewers.yml
+++ b/.github/workflows/auto-assign-pr-reviewers.yml
@@ -1,0 +1,17 @@
+# This is a basic workflow to help you get started with Actions
+
+name: "Auto-assign PRs to the Pins team as reviewer"
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  assign-reviewers:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Auto Assign Reviewer to the Pins Tea,
+      uses: shufo/auto-assign-reviewer-by-files@v1.1.1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        config: .github/assign-by-files.yml


### PR DESCRIPTION
This PR will contain a new GitHub workflow for automatically assign @ThePinsTeam as a PR reviewer.